### PR TITLE
CM4 NVME fix

### DIFF
--- a/drivers/nvme/nvme_show.c
+++ b/drivers/nvme/nvme_show.c
@@ -113,7 +113,7 @@ int nvme_print_info(struct udevice *udev)
 	if (!ctrl)
 		return -ENOMEM;
 
-	if (nvme_identify(dev, 0, 1, (dma_addr_t)(long)ctrl)) {
+	if (nvme_identify(dev, 0, 1, ctrl)) {
 		ret = -EIO;
 		goto free_ctrl;
 	}
@@ -128,7 +128,7 @@ int nvme_print_info(struct udevice *udev)
 		goto free_ctrl;
 	}
 
-	if (nvme_identify(dev, ns->ns_id, 0, (dma_addr_t)(long)id)) {
+	if (nvme_identify(dev, ns->ns_id, 0, id)) {
 		ret = -EIO;
 		goto free_id;
 	}

--- a/include/nvme.h
+++ b/include/nvme.h
@@ -23,7 +23,7 @@ struct nvme_dev;
  *		-EIO on command execution fails
  */
 int nvme_identify(struct nvme_dev *dev, unsigned nsid,
-		  unsigned cns, dma_addr_t dma_addr);
+		  unsigned cns, void *buffer);
 
 /**
  * nvme_get_features - retrieve the attributes of the feature specified


### PR DESCRIPTION

address memory translation between PCIe and CPU in Broadcom SOCs